### PR TITLE
adding a section to status ui to show points invested into each stat

### DIFF
--- a/addons/addonloader.lua
+++ b/addons/addonloader.lua
@@ -12,6 +12,7 @@ dofile("../addons/mapfogviewer/mapfogviewer.lua");
 dofile("../addons/monsterframes/monsterframes.lua");
 dofile("../addons/monstertracker/monstertracker.lua");
 dofile("../addons/channelsurfer/channelsurfer.lua");
+dofile("../addons/showInvestedStatPoints/showInvestedStatPoints.lua");
 
 --do not touch below here
 local addonLoaderFrame = ui.GetFrame("addonloader");

--- a/addons/showInvestedStatPoints/showInvestedStatPoints.lua
+++ b/addons/showInvestedStatPoints/showInvestedStatPoints.lua
@@ -1,0 +1,66 @@
+function STATUS_INFO_HOOKED(frame)
+    _G["STATUS_INFO_OLD"](frame);
+    
+    local Status_gboxctrl = frame:GetChild('statusGbox');
+    local Status_internal_gboxctrl = GET_CHILD(Status_gboxctrl,'internalstatusBox');
+    
+    local pc = GetMyPCObject();
+    
+    local stats = {};
+    stats["statPC"] = {};           -- this is how many points you've allocated to it
+
+    local y = 23 + 10; -- 23 to pad for the hight of the last CRichText, 10 for spacer
+    -- the last control that STATUS_INFO adds; use this to place ours at the end of the list
+    local controlSet = Status_internal_gboxctrl:GetChild("Velnias_Atk");
+    if controlSet:GetY() > 0 then
+        y = y + controlSet:GetY();
+    else
+        -- if we can't find the last entry in the status box, pick a high arbitrary number
+        y = 1500; -- should be far enough down to not obstruct other values
+    end
+    
+    -- for each type of STAT (excludes hidden stat LUCK)
+    for i = 0 , STAT_COUNT - 1 do
+        local statStr = GetStatTypeStr(i);
+        stats["statPC"][statStr] = GET_STAT_PROPERTY_FROM_PC("STAT", statStr, pc);
+        
+        -- display the points we have allocated on the end of the list
+        y = ADD_TO_STATUS(Status_internal_gboxctrl, statStr, stats["statPC"][statStr], y);
+    end
+    
+    Status_internal_gboxctrl:SetScrollPos(0);
+    frame:Invalidate();
+    
+end
+
+function ADD_TO_STATUS(gboxctrl, attibuteName, value, y)
+    local controlSet = gboxctrl:CreateOrGetControlSet('status_stat', attibuteName, 0, y);
+    
+    tolua.cast(controlSet, "ui::CControlSet");
+    local title = GET_CHILD(controlSet, "title", "ui::CRichText");
+    if attibuteName == "MNA" then
+        title:SetText("Points invested in SPR");
+    else
+        title:SetText("Points invested in "..attibuteName);
+    end
+
+    local stat = GET_CHILD(controlSet, "stat", "ui::CRichText");
+    title:SetUseOrifaceRect(true);
+    stat:SetUseOrifaceRect(true);
+    stat:SetText(value);
+
+    controlSet:Resize(controlSet:GetWidth(), stat:GetHeight());
+    
+    return y + controlSet:GetHeight();
+end
+
+local STATUS_INFOHook = "STATUS_INFO";
+
+if _G["STATUS_INFO_OLD"] == nil then
+    _G["STATUS_INFO_OLD"] = _G[STATUS_INFOHook];
+    _G[STATUS_INFOHook] = STATUS_INFO_HOOKED;
+else
+    _G[STATUS_INFOHook] = STATUS_INFO_HOOKED;
+end
+
+ui.SysMsg("Show Invested Stat Points loaded!");

--- a/addons/utility.lua
+++ b/addons/utility.lua
@@ -26,3 +26,114 @@ function RIGHT_PAD(str, len, char)
 
 	return str .. string.rep(char, len - #str)
 end
+
+function GET_STAT_PROPERTY_FROM_PC(typeStr, statStr, pc)
+    local errorText = "Param was nil";
+    
+    if typeStr ~= nil and statStr ~= nil and pc ~= nil then
+
+        if typeStr == "JOB" then
+            if statStr == "STR" then
+                return pc.STR_JOB;
+            elseif statStr == "DEX" then
+                return pc.DEX_JOB;
+            elseif statStr == "CON" then
+                return pc.CON_JOB;
+            elseif statStr == "INT" then
+                return pc.INT_JOB;
+            elseif statStr == "MNA" then
+                return pc.MNA_JOB;
+            elseif statStr == "LUCK" then
+                return pc.LUCK_JOB;
+            else
+                errorText = "Could not find stat "..statStr.." for type "..typeStr;
+            end
+
+        elseif typeStr == "STAT" then
+            if statStr == "STR" then
+                return pc.STR_STAT;
+            elseif statStr == "DEX" then
+                return pc.DEX_STAT;
+            elseif statStr == "CON" then
+                return pc.CON_STAT;
+            elseif statStr == "INT" then
+                return pc.INT_STAT;
+            elseif statStr == "MNA" then
+                return pc.MNA_STAT;
+            elseif statStr == "LUCK" then
+                return pc.LUCK_STAT;
+            else
+                errorText = "Could not find stat "..statStr.." for type "..typeStr;
+            end
+        
+        elseif typeStr == "BONUS" then
+            if statStr == "STR" then
+                return pc.STR_Bonus;
+            elseif statStr == "DEX" then
+                return pc.DEX_Bonus;
+            elseif statStr == "CON" then
+                return pc.CON_Bonus;
+            elseif statStr == "INT" then
+                return pc.INT_Bonus;
+            elseif statStr == "MNA" then
+                return pc.MNA_Bonus;
+            else
+                errorText = "Could not find stat "..statStr.." for type "..typeStr;
+            end
+        
+        elseif typeStr == "ADD" then
+            if statStr == "STR" then
+                return pc.STR_ADD;
+            elseif statStr == "DEX" then
+                return pc.DEX_ADD;
+            elseif statStr == "CON" then
+                return pc.CON_ADD;
+            elseif statStr == "INT" then
+                return pc.INT_ADD;
+            elseif statStr == "MNA" then
+                return pc.MNA_ADD;
+            elseif statStr == "LUCK" then
+                return pc.LUCK_ADD;
+            else
+                errorText = "Could not find stat "..statStr.." for type "..typeStr;
+            end
+        
+        elseif typeStr == "BM" then
+            if statStr == "STR" then
+                return pc.STR_BM;
+            elseif statStr == "DEX" then
+                return pc.DEX_BM;
+            elseif statStr == "CON" then
+                return pc.CON_BM;
+            elseif statStr == "INT" then
+                return pc.INT_BM;
+            elseif statStr == "MNA" then
+                return pc.MNA_BM;
+            elseif statStr == "LUCK" then
+                return pc.LUCK_BM;
+            else
+                errorText = "Could not find stat "..statStr.." for type "..typeStr;
+            end
+        
+        else
+            errorText = "Could not find a property for type "..typeStr;
+        end
+    end
+    
+    ui.SysMsg(errorText);
+    return 0;
+end
+
+function IS_VALID_STAT(statStr, includeLuck)
+    if statStr == "LUCK" then
+        return includeLuck;
+    elseif statStr == "STR" or
+           statStr == "DEX" or
+           statStr == "CON" or
+           statStr == "INT" or
+           statStr == "MNA" then
+        return true;
+    end
+    
+    return false;
+end


### PR DESCRIPTION
cleaned up branches and reforked from your latest changes. sorry for the pull spam

this adds nice to have stat related methods in the utilities and will show invested points in the Status menu. 
The stat calc on TOS base is wildly inaccurate as ToS adds all sorts of odd bonuses to stats, allows extra stat allocation (such as stats obtained from goddess statues), and generally shows very little as to how it actually calculates things. Even the SCR stat methods don't come up with the displayed amount...