### PR TITLE
Add addon status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tree of Savior Lua Mods
+# Tree of Savior Lua Mods [![Addon Safe](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-safe.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 
 ### Features
 


### PR DESCRIPTION
I'm proposing a badge pattern for Tree of Savior addons.
Using these badges, users can easily understand that the system they are using is approved / is safe / have a unknown status / is unsafe.
Read more at [Awesome ToS #addons-badges](https://github.com/lubien/awesome-tos#addons-badges).
Hope you like the idea.