### PR TITLE
add size to normal mobs. correct elite mob display. cleanup a little.

### DIFF
--- a/addons/monsterframes/monsterframes.lua
+++ b/addons/monsterframes/monsterframes.lua
@@ -12,22 +12,22 @@ function SHOW_PROPERTY_WINDOW(frame, monCls, targetInfoProperty, monsterProperty
 end
 
 function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
-	_G["TGTINFO_TARGET_SET_OLD"](frame, msg, argStr, argNum);
+    _G["TGTINFO_TARGET_SET_OLD"](frame, msg, argStr, argNum);
 
-	local targetinfo = info.GetTargetInfo(session.GetTargetHandle());
+    local targetinfo = info.GetTargetInfo(session.GetTargetHandle());
 
-	if argStr == "None" then
-		return;
-	end
+    if argStr == "None" then
+        return;
+    end
 
-	local stat = info.GetStat(session.GetTargetHandle());
-	if stat == nil then
-		return;
-	end
+    local stat = info.GetStat(session.GetTargetHandle());
+    if stat == nil then
+        return;
+    end
 
-	if targetinfo == nil then
-		return;
-	end
+    if nil == targetinfo then
+        return;
+    end
 
 	local monactor = world.GetActor(session.GetTargetHandle());
 	local montype = monactor:GetType();
@@ -37,6 +37,22 @@ function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
 		return;
 	end
 
+    -- hp
+    local numhp = nil;
+    if targetinfo.isElite == 1 then
+        numhp = frame:CreateOrGetControl("richtext", "numhp", 3, -5, 176, 115);
+    else
+        numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
+    end
+    if numhp ~= nil then
+        tolua.cast(numhp, "ui::CRichText");
+        numhp:ShowWindow(1);
+        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+        numhp:SetTextAlign("center", "center");
+        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+        numhp:SetFontName("white_16_ol");
+    end
+
 	local xPosition = 100;
 	local yPosition = 17;
 	local propertyWidth = 35;
@@ -45,23 +61,7 @@ function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
 		xPosition = 117;
 		yPosition = 12;
 	end
-
-	-- hp
-	local numhp = nil;
-	if targetinfo.isElite == 1 then
-		numhp = frame:CreateOrGetControl("richtext", "numhp", 3, -5, 176, 115);
-	else
-		numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
-	end
-	if numhp ~= nil then
-		tolua.cast(numhp, "ui::CRichText");
-		numhp:ShowWindow(1);
-		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-		numhp:SetTextAlign("center", "center");
-		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-		numhp:SetFontName("white_16_ol");
-	end
-
+	
 	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
 	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
 	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
@@ -98,27 +98,27 @@ function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
 end
 
 function TARGETINFO_ON_MSG_HOOKED(frame, msg, argStr, argNum)
-	local oldf = _G["TARGETINFO_ON_MSG_OLD"];
-	oldf(frame, msg, str, exp, tableinfo);
+    local oldf = _G["TARGETINFO_ON_MSG_OLD"];
+    oldf(frame, msg, str, exp, tableinfo);
 
-	if frame == nil then
-		return;
-	end
+    if frame == nil then
+        return;
+    end
 
-	if msg == 'TARGET_UPDATE' then
-		local stat = info.GetStat(session.GetTargetHandle());
-		if stat == nil then
-			return;
-		end
+    if msg == 'TARGET_UPDATE' then
+        local stat = info.GetStat(session.GetTargetHandle());
+        if stat == nil then
+            return;
+        end
 
-		local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
-		tolua.cast(numhp, "ui::CRichText");
-		numhp:ShowWindow(1);
-		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-		numhp:SetTextAlign("center", "center");
-		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-		numhp:SetFontName("white_16_ol");
-	end
+        local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
+        tolua.cast(numhp, "ui::CRichText");
+        numhp:ShowWindow(1);
+        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+        numhp:SetTextAlign("center", "center");
+        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+        numhp:SetFontName("white_16_ol");
+    end
 end
 
 function TARGETINFOTOBOSS_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
@@ -135,7 +135,7 @@ function TARGETINFOTOBOSS_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
 	end
 
 	local targetinfo = info.GetTargetInfo(argNum);
-	if targetinfo == nil then
+	if nil == targetinfo then
 		return;
 	end
 

--- a/addons/monsterframes/monsterframes.lua
+++ b/addons/monsterframes/monsterframes.lua
@@ -1,14 +1,14 @@
 function SHOW_PROPERTY_WINDOW(frame, monCls, targetInfoProperty, monsterPropertyIcon, x, y, spacingX, spacingY)
-	local propertyType = frame:CreateOrGetControl("picture", monsterPropertyIcon .. "_icon", 0, 0, 100, 40);
-	tolua.cast(propertyType, "ui::CPicture");
-	if (targetInfoProperty == nil and monsterPropertyIcon == "EffectiveAtkType") or (targetInfoProperty ~= nil) then
-		propertyType:SetGravity(ui.LEFT, ui.TOP);
-		propertyType:SetImage(GET_MON_PROPICON_BY_PROPNAME(monsterPropertyIcon, monCls));
-		propertyType:SetOffset((x + spacingX), (y - spacingY));
-		propertyType:ShowWindow(1);
-	else
-		propertyType:ShowWindow(0);
-	end
+    local propertyType = frame:CreateOrGetControl("picture", monsterPropertyIcon .. "_icon", 0, 0, 100, 40);
+    tolua.cast(propertyType, "ui::CPicture");
+    if (targetInfoProperty == nil and monsterPropertyIcon == "EffectiveAtkType") or (targetInfoProperty ~= nil) then
+        propertyType:SetGravity(ui.LEFT, ui.TOP);
+        propertyType:SetImage(GET_MON_PROPICON_BY_PROPNAME(monsterPropertyIcon, monCls));
+        propertyType:SetOffset((x + spacingX), (y - spacingY));
+        propertyType:ShowWindow(1);
+    else
+        propertyType:ShowWindow(0);
+    end
 end
 
 function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
@@ -25,53 +25,76 @@ function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
         return;
     end
 
-    if nil == targetinfo then
+    if targetinfo == nil then
         return;
     end
 
-	local monactor = world.GetActor(session.GetTargetHandle());
-	local montype = monactor:GetType();
-	local monCls = GetClassByType("Monster", montype);
+    local monactor = world.GetActor(session.GetTargetHandle());
+    local montype = monactor:GetType();
+    local monCls = GetClassByType("Monster", montype);
 
-	if monCls == nil then
-		return;
-	end
+    if monCls == nil then
+        return;
+    end
+
+    local xPosition = 100;
+    local yPosition = 17;
+    local propertyWidth = 35;
+
+    if targetinfo.isElite == 1 then
+        xPosition = 117;
+        yPosition = 12;
+    end
 
     -- hp
-    local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
-    tolua.cast(numhp, "ui::CRichText");
-    numhp:ShowWindow(1);
-    numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-    numhp:SetTextAlign("center", "center");
-    numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-    numhp:SetFontName("white_16_ol");
+    local numhp = nil;
+    if targetinfo.isElite == 1 then
+        numhp = frame:CreateOrGetControl("richtext", "numhp", 3, -5, 176, 115);
+    else
+        numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
+    end
+    if numhp ~= nil then
+        tolua.cast(numhp, "ui::CRichText");
+        numhp:ShowWindow(1);
+        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+        numhp:SetTextAlign("center", "center");
+        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+        numhp:SetFontName("white_16_ol");
+    end
 
-	local startX = 100;
-	local offsetX = 50;
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
 
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", 100, 17, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", 135, 17, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", 170, 17, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", 205, 17, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", 240, 17, 10, 10);
+    local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
+    tolua.cast(targetSizeText, "ui::CRichText");
+    if targetinfo.size ~= nil then
+        targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
+        targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
+        targetSizeText:ShowWindow(1);
+    else
+        targetSizeText:ShowWindow(0);
+    end
 
-	local wiki = GetWikiByName(monCls.Journal);
+    local wiki = GetWikiByName(monCls.Journal);
 
-	if wiki ~= nil then
-		local killCount = GetWikiIntProp(wiki, "KillCount");
-		local killsRequired = GetClass('Journal_monkill_reward', monCls.Journal).Count1;
+    if wiki ~= nil then
+        local killCount = GetWikiIntProp(wiki, "KillCount");
+        local killsRequired = GetClass('Journal_monkill_reward', monCls.Journal).Count1;
 
-		local killCountText = frame:CreateOrGetControl("richtext", "killCountText", 0, 0, 100, 40);
-		tolua.cast(killCountText, "ui::CRichText");
-		if targetinfo.size ~= nil then
-			killCountText:SetOffset(0, 0);
-			killCountText:SetFontName("white_16_ol");
-			killCountText:SetText(ADD_THOUSANDS_SEPARATOR(killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(killsRequired));
-			killCountText:ShowWindow(1);
-		else
-			killCountText:ShowWindow(0);
-		end
-	end
+        local killCountText = frame:CreateOrGetControl("richtext", "killCountText", 0, 0, 100, 40);
+        tolua.cast(killCountText, "ui::CRichText");
+        if targetinfo.size ~= nil then
+            killCountText:SetOffset(0, 0);
+            killCountText:SetFontName("white_16_ol");
+            killCountText:SetText(ADD_THOUSANDS_SEPARATOR(killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(killsRequired));
+            killCountText:ShowWindow(1);
+        else
+            killCountText:ShowWindow(0);
+        end
+    end
 end
 
 function TARGETINFO_ON_MSG_HOOKED(frame, msg, argStr, argNum)
@@ -88,8 +111,6 @@ function TARGETINFO_ON_MSG_HOOKED(frame, msg, argStr, argNum)
             return;
         end
 
-        local targetinfo = info.GetTargetInfo(session.GetTargetHandle());
-
         local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
         tolua.cast(numhp, "ui::CRichText");
         numhp:ShowWindow(1);
@@ -101,78 +122,78 @@ function TARGETINFO_ON_MSG_HOOKED(frame, msg, argStr, argNum)
 end
 
 function TARGETINFOTOBOSS_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
-	_G["TARGETINFOTOBOSS_TARGET_SET_OLD"](frame, msg, argStr, argNum);
+    _G["TARGETINFOTOBOSS_TARGET_SET_OLD"](frame, msg, argStr, argNum);
 
-	if argStr == "None" or argNum == nil then
-		return;
-	end
+    if argStr == "None" or argNum == nil then
+        return;
+    end
 
-	local stat = info.GetStat(session.GetTargetHandle());
+    local stat = info.GetStat(session.GetTargetHandle());
 
-	if stat == nil then
-		return;
-	end
+    if stat == nil then
+        return;
+    end
 
-	local targetinfo = info.GetTargetInfo(argNum);
-	if nil == targetinfo then
-		return;
-	end
+    local targetinfo = info.GetTargetInfo(argNum);
+    if targetinfo == nil then
+        return;
+    end
 
-	local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
-	tolua.cast(numhp, "ui::CRichText");
-	numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-	numhp:SetTextAlign("center", "center");
-	numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-	numhp:SetFontName("white_16_ol");
-	numhp:ShowWindow(1);
+    local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
+    tolua.cast(numhp, "ui::CRichText");
+    numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+    numhp:SetTextAlign("center", "center");
+    numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+    numhp:SetFontName("white_16_ol");
+    numhp:ShowWindow(1);
 
-	local monactor = world.GetActor(session.GetTargetHandle());
-	local montype = monactor:GetType();
-	local monCls = GetClassByType("Monster", montype);
+    local monactor = world.GetActor(session.GetTargetHandle());
+    local montype = monactor:GetType();
+    local monCls = GetClassByType("Monster", montype);
 
-	if monCls == nil then
-		return;
-	end
+    if monCls == nil then
+        return;
+    end
 
-	local xPosition = 0;
-	local yPosition = 20;
-	local propertyWidth = 35;
+    local xPosition = 0;
+    local yPosition = 20;
+    local propertyWidth = 35;
 
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
-	SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
+    SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
 
-	local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
-	tolua.cast(targetSizeText, "ui::CRichText");
-	if targetinfo.size ~= nil then
-		targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
-		targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
-		targetSizeText:ShowWindow(1);
-	else
-		targetSizeText:ShowWindow(0);
-	end
+    local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
+    tolua.cast(targetSizeText, "ui::CRichText");
+    if targetinfo.size ~= nil then
+        targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
+        targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
+        targetSizeText:ShowWindow(1);
+    else
+        targetSizeText:ShowWindow(0);
+    end
 end
 
 function TARGETINFOTOBOSS_ON_MSG_HOOKED(frame, msg, argStr, argNum)
-	_G["TARGETINFOTOBOSS_ON_MSG_OLD"](frame, msg, argStr, argNum);
+    _G["TARGETINFOTOBOSS_ON_MSG_OLD"](frame, msg, argStr, argNum);
 
-	if msg == "TARGET_UPDATE" then
-		local stat = info.GetStat(session.GetTargetHandle());
+    if msg == "TARGET_UPDATE" then
+        local stat = info.GetStat(session.GetTargetHandle());
 
-		if stat == nil then
-			return;
-		end
+        if stat == nil then
+            return;
+        end
 
-		local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
-		tolua.cast(numhp, "ui::CRichText");
-		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-		numhp:SetTextAlign("center", "center");
-		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-		numhp:SetFontName("white_16_ol");
-		numhp:ShowWindow(1);
-	end
+        local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
+        tolua.cast(numhp, "ui::CRichText");
+        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+        numhp:SetTextAlign("center", "center");
+        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+        numhp:SetFontName("white_16_ol");
+        numhp:ShowWindow(1);
+    end
 end
 
 SETUP_HOOK(TGTINFO_TARGET_SET_HOOKED, "TGTINFO_TARGET_SET");

--- a/addons/monsterframes/monsterframes.lua
+++ b/addons/monsterframes/monsterframes.lua
@@ -1,199 +1,199 @@
 function SHOW_PROPERTY_WINDOW(frame, monCls, targetInfoProperty, monsterPropertyIcon, x, y, spacingX, spacingY)
-    local propertyType = frame:CreateOrGetControl("picture", monsterPropertyIcon .. "_icon", 0, 0, 100, 40);
-    tolua.cast(propertyType, "ui::CPicture");
-    if (targetInfoProperty == nil and monsterPropertyIcon == "EffectiveAtkType") or (targetInfoProperty ~= nil) then
-        propertyType:SetGravity(ui.LEFT, ui.TOP);
-        propertyType:SetImage(GET_MON_PROPICON_BY_PROPNAME(monsterPropertyIcon, monCls));
-        propertyType:SetOffset((x + spacingX), (y - spacingY));
-        propertyType:ShowWindow(1);
-    else
-        propertyType:ShowWindow(0);
-    end
+	local propertyType = frame:CreateOrGetControl("picture", monsterPropertyIcon .. "_icon", 0, 0, 100, 40);
+	tolua.cast(propertyType, "ui::CPicture");
+	if (targetInfoProperty == nil and monsterPropertyIcon == "EffectiveAtkType") or (targetInfoProperty ~= nil) then
+		propertyType:SetGravity(ui.LEFT, ui.TOP);
+		propertyType:SetImage(GET_MON_PROPICON_BY_PROPNAME(monsterPropertyIcon, monCls));
+		propertyType:SetOffset((x + spacingX), (y - spacingY));
+		propertyType:ShowWindow(1);
+	else
+		propertyType:ShowWindow(0);
+	end
 end
 
 function TGTINFO_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
-    _G["TGTINFO_TARGET_SET_OLD"](frame, msg, argStr, argNum);
+	_G["TGTINFO_TARGET_SET_OLD"](frame, msg, argStr, argNum);
 
-    local targetinfo = info.GetTargetInfo(session.GetTargetHandle());
+	local targetinfo = info.GetTargetInfo(session.GetTargetHandle());
 
-    if argStr == "None" then
-        return;
-    end
+	if argStr == "None" then
+		return;
+	end
 
-    local stat = info.GetStat(session.GetTargetHandle());
-    if stat == nil then
-        return;
-    end
+	local stat = info.GetStat(session.GetTargetHandle());
+	if stat == nil then
+		return;
+	end
 
-    if targetinfo == nil then
-        return;
-    end
+	if targetinfo == nil then
+		return;
+	end
 
-    local monactor = world.GetActor(session.GetTargetHandle());
-    local montype = monactor:GetType();
-    local monCls = GetClassByType("Monster", montype);
+	local monactor = world.GetActor(session.GetTargetHandle());
+	local montype = monactor:GetType();
+	local monCls = GetClassByType("Monster", montype);
 
-    if monCls == nil then
-        return;
-    end
+	if monCls == nil then
+		return;
+	end
 
-    local xPosition = 100;
-    local yPosition = 17;
-    local propertyWidth = 35;
+	local xPosition = 100;
+	local yPosition = 17;
+	local propertyWidth = 35;
 
-    if targetinfo.isElite == 1 then
-        xPosition = 117;
-        yPosition = 12;
-    end
+	if targetinfo.isElite == 1 then
+		xPosition = 117;
+		yPosition = 12;
+	end
 
-    -- hp
-    local numhp = nil;
-    if targetinfo.isElite == 1 then
-        numhp = frame:CreateOrGetControl("richtext", "numhp", 3, -5, 176, 115);
-    else
-        numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
-    end
-    if numhp ~= nil then
-        tolua.cast(numhp, "ui::CRichText");
-        numhp:ShowWindow(1);
-        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-        numhp:SetTextAlign("center", "center");
-        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-        numhp:SetFontName("white_16_ol");
-    end
+	-- hp
+	local numhp = nil;
+	if targetinfo.isElite == 1 then
+		numhp = frame:CreateOrGetControl("richtext", "numhp", 3, -5, 176, 115);
+	else
+		numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
+	end
+	if numhp ~= nil then
+		tolua.cast(numhp, "ui::CRichText");
+		numhp:ShowWindow(1);
+		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+		numhp:SetTextAlign("center", "center");
+		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+		numhp:SetFontName("white_16_ol");
+	end
 
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
 
-    local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
-    tolua.cast(targetSizeText, "ui::CRichText");
-    if targetinfo.size ~= nil then
-        targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
-        targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
-        targetSizeText:ShowWindow(1);
-    else
-        targetSizeText:ShowWindow(0);
-    end
+	local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
+	tolua.cast(targetSizeText, "ui::CRichText");
+	if targetinfo.size ~= nil then
+		targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
+		targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
+		targetSizeText:ShowWindow(1);
+	else
+		targetSizeText:ShowWindow(0);
+	end
 
-    local wiki = GetWikiByName(monCls.Journal);
+	local wiki = GetWikiByName(monCls.Journal);
 
-    if wiki ~= nil then
-        local killCount = GetWikiIntProp(wiki, "KillCount");
-        local killsRequired = GetClass('Journal_monkill_reward', monCls.Journal).Count1;
+	if wiki ~= nil then
+		local killCount = GetWikiIntProp(wiki, "KillCount");
+		local killsRequired = GetClass('Journal_monkill_reward', monCls.Journal).Count1;
 
-        local killCountText = frame:CreateOrGetControl("richtext", "killCountText", 0, 0, 100, 40);
-        tolua.cast(killCountText, "ui::CRichText");
-        if targetinfo.size ~= nil then
-            killCountText:SetOffset(0, 0);
-            killCountText:SetFontName("white_16_ol");
-            killCountText:SetText(ADD_THOUSANDS_SEPARATOR(killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(killsRequired));
-            killCountText:ShowWindow(1);
-        else
-            killCountText:ShowWindow(0);
-        end
-    end
+		local killCountText = frame:CreateOrGetControl("richtext", "killCountText", 0, 0, 100, 40);
+		tolua.cast(killCountText, "ui::CRichText");
+		if targetinfo.size ~= nil then
+			killCountText:SetOffset(0, 0);
+			killCountText:SetFontName("white_16_ol");
+			killCountText:SetText(ADD_THOUSANDS_SEPARATOR(killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(killsRequired));
+			killCountText:ShowWindow(1);
+		else
+			killCountText:ShowWindow(0);
+		end
+	end
 end
 
 function TARGETINFO_ON_MSG_HOOKED(frame, msg, argStr, argNum)
-    local oldf = _G["TARGETINFO_ON_MSG_OLD"];
-    oldf(frame, msg, str, exp, tableinfo);
+	local oldf = _G["TARGETINFO_ON_MSG_OLD"];
+	oldf(frame, msg, str, exp, tableinfo);
 
-    if frame == nil then
-        return;
-    end
+	if frame == nil then
+		return;
+	end
 
-    if msg == 'TARGET_UPDATE' then
-        local stat = info.GetStat(session.GetTargetHandle());
-        if stat == nil then
-            return;
-        end
+	if msg == 'TARGET_UPDATE' then
+		local stat = info.GetStat(session.GetTargetHandle());
+		if stat == nil then
+			return;
+		end
 
-        local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
-        tolua.cast(numhp, "ui::CRichText");
-        numhp:ShowWindow(1);
-        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-        numhp:SetTextAlign("center", "center");
-        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-        numhp:SetFontName("white_16_ol");
-    end
+		local numhp = frame:CreateOrGetControl("richtext", "numhp", -17, 0, 176, 115);
+		tolua.cast(numhp, "ui::CRichText");
+		numhp:ShowWindow(1);
+		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+		numhp:SetTextAlign("center", "center");
+		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. "/" .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+		numhp:SetFontName("white_16_ol");
+	end
 end
 
 function TARGETINFOTOBOSS_TARGET_SET_HOOKED(frame, msg, argStr, argNum)
-    _G["TARGETINFOTOBOSS_TARGET_SET_OLD"](frame, msg, argStr, argNum);
+	_G["TARGETINFOTOBOSS_TARGET_SET_OLD"](frame, msg, argStr, argNum);
 
-    if argStr == "None" or argNum == nil then
-        return;
-    end
+	if argStr == "None" or argNum == nil then
+		return;
+	end
 
-    local stat = info.GetStat(session.GetTargetHandle());
+	local stat = info.GetStat(session.GetTargetHandle());
 
-    if stat == nil then
-        return;
-    end
+	if stat == nil then
+		return;
+	end
 
-    local targetinfo = info.GetTargetInfo(argNum);
-    if targetinfo == nil then
-        return;
-    end
+	local targetinfo = info.GetTargetInfo(argNum);
+	if targetinfo == nil then
+		return;
+	end
 
-    local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
-    tolua.cast(numhp, "ui::CRichText");
-    numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-    numhp:SetTextAlign("center", "center");
-    numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-    numhp:SetFontName("white_16_ol");
-    numhp:ShowWindow(1);
+	local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
+	tolua.cast(numhp, "ui::CRichText");
+	numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+	numhp:SetTextAlign("center", "center");
+	numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+	numhp:SetFontName("white_16_ol");
+	numhp:ShowWindow(1);
 
-    local monactor = world.GetActor(session.GetTargetHandle());
-    local montype = monactor:GetType();
-    local monCls = GetClassByType("Monster", montype);
+	local monactor = world.GetActor(session.GetTargetHandle());
+	local montype = monactor:GetType();
+	local monCls = GetClassByType("Monster", montype);
 
-    if monCls == nil then
-        return;
-    end
+	if monCls == nil then
+		return;
+	end
 
-    local xPosition = 0;
-    local yPosition = 20;
-    local propertyWidth = 35;
+	local xPosition = 0;
+	local yPosition = 20;
+	local propertyWidth = 35;
 
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
-    SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.raceType, "RaceType", xPosition + (0 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.attribute, "Attribute", xPosition + (1 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, targetinfo.armorType, "ArmorMaterial", xPosition + (2 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, monCls["MoveType"], "MoveType", xPosition + (3 * propertyWidth), yPosition, 10, 10);
+	SHOW_PROPERTY_WINDOW(frame, monCls, nil, "EffectiveAtkType", xPosition + (4 * propertyWidth), yPosition, 10, 10);
 
-    local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
-    tolua.cast(targetSizeText, "ui::CRichText");
-    if targetinfo.size ~= nil then
-        targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
-        targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
-        targetSizeText:ShowWindow(1);
-    else
-        targetSizeText:ShowWindow(0);
-    end
+	local targetSizeText = frame:CreateOrGetControl("richtext", "targetSizeText", 0, 0, 100, 40);
+	tolua.cast(targetSizeText, "ui::CRichText");
+	if targetinfo.size ~= nil then
+		targetSizeText:SetOffset(xPosition + (5 * propertyWidth) + 10, yPosition - 8);
+		targetSizeText:SetText("{@st41}{s28}" .. targetinfo.size);
+		targetSizeText:ShowWindow(1);
+	else
+		targetSizeText:ShowWindow(0);
+	end
 end
 
 function TARGETINFOTOBOSS_ON_MSG_HOOKED(frame, msg, argStr, argNum)
-    _G["TARGETINFOTOBOSS_ON_MSG_OLD"](frame, msg, argStr, argNum);
+	_G["TARGETINFOTOBOSS_ON_MSG_OLD"](frame, msg, argStr, argNum);
 
-    if msg == "TARGET_UPDATE" then
-        local stat = info.GetStat(session.GetTargetHandle());
+	if msg == "TARGET_UPDATE" then
+		local stat = info.GetStat(session.GetTargetHandle());
 
-        if stat == nil then
-            return;
-        end
+		if stat == nil then
+			return;
+		end
 
-        local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
-        tolua.cast(numhp, "ui::CRichText");
-        numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
-        numhp:SetTextAlign("center", "center");
-        numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
-        numhp:SetFontName("white_16_ol");
-        numhp:ShowWindow(1);
-    end
+		local numhp = frame:CreateOrGetControl("richtext", "numhp", -10, 18, 176, 115);
+		tolua.cast(numhp, "ui::CRichText");
+		numhp:SetGravity(ui.CENTER_HORZ, ui.TOP);
+		numhp:SetTextAlign("center", "center");
+		numhp:SetText(ADD_THOUSANDS_SEPARATOR(stat.HP) .. " / " .. ADD_THOUSANDS_SEPARATOR(stat.maxHP));
+		numhp:SetFontName("white_16_ol");
+		numhp:ShowWindow(1);
+	end
 end
 
 SETUP_HOOK(TGTINFO_TARGET_SET_HOOKED, "TGTINFO_TARGET_SET");


### PR DESCRIPTION
Added the size test back to normal mobs.
Corrected the display for elite class mobs.
Cleaned up the x and y position for normal mobs. They now use the same pattern as boss monsters.

Not sure how to fix #64 yet.
TGTINFO_TARGET_SET_HOOKED is being called during boss fights on the minions (even other mobs that are out of the instance sometimes lol) and SHOW_PROPERTY_WINDOW ends up using the controls which were created for the boss.
Haven't been able to think of a sane way to exit TGTINFO_TARGET_SET_HOOKED  early if we're in a boss fight. Tried silly things like checking frame and checking targetinfo.isBoss but couldn't get anything working correctly.
Hopefully another pull will solve it. If I have more time, I'll continue to look into it.